### PR TITLE
Removes an unnecessary check for webkit in the window.location string

### DIFF
--- a/js/effects.js
+++ b/js/effects.js
@@ -422,11 +422,8 @@ function createTelephonizer() {
 }
 
 function createDelay() {
-    var delayNode = null;
-    if (window.location.search.substring(1) == "webkit")
-        delayNode = audioContext.createDelay();
-    else
-        delayNode = audioContext.createDelay();
+    var delayNode = audioContext.createDelay();
+
     delayNode.delayTime.value = parseFloat( document.getElementById("dtime").value );
     dtime = delayNode;
 


### PR DESCRIPTION
There seems to be an if/else checking for webkit that does the same thing in both cases. If it isn't necessary, perhaps it would be better to remove it?