### PR TITLE
Adds link to demo page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 I whipped this app up to test live audio input, letting the user select a few common tunable effects and see (and hear) the effects.  It's also a good demo of how to build chorus and flanging effects in WebAudio.
 
-Check it out, feel free to fork, submit pull requests, etc.
+Check it out [here](https://webaudiodemos.appspot.com/input/), feel free to fork, submit pull requests, etc.
 
 -Chris


### PR DESCRIPTION
This is a tiny PR, but I thought it would be useful for people visiting the repository to have a link to the appspot page. Since the demo is not a gh-pages, it's not evident where it is hosted.

Cheers,